### PR TITLE
fix missing image issue

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -37,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || '/placeholder.png'}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Fix issue #1  by adding a placeholder image when a user forgets to enter an image URL
<img width="1353" alt="Screenshot 2023-01-10 at 11 37 44 AM" src="https://user-images.githubusercontent.com/44832446/211474540-01d77257-71de-44d9-ac6a-c57be6d95612.png">
